### PR TITLE
New Score Threshold

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -23,7 +23,7 @@ VALI_REFRESH_MATCHES = 60 * 30
 BASE_MINER_PREDICTION_SCORE = 0.01
 
 # Number of miners to send predictions to. -1 == all
-NUM_MINERS_TO_SEND_TO = 25
+NUM_MINERS_TO_SEND_TO = 20
 
 # Minimum time in seconds predictions are allowed before match begins
 MIN_PREDICTION_TIME_THRESHOLD = 60 * 30
@@ -35,7 +35,7 @@ MAX_PREDICTION_DAYS_THRESHOLD = 2
 MAX_BATCHSIZE_FOR_SCORING = 25
 
 # Cut off days to attempt to score predictions. i.e. Any predictions not scored with X days will be left behind
-SCORING_CUTOFF_IN_DAYS = 3
+SCORING_CUTOFF_IN_DAYS = 10
 
 # Interval in minutes that we attempt to score predictions
 SCORING_INTERVAL_IN_MINUTES = 1
@@ -45,6 +45,8 @@ MAX_TEAM_NAME_LENGTH = 32
 
 ########## SCORING CONSTANTS ##############
 CORRECT_MATCH_WINNER_SCORE = 0.5
+# The score a miner must achieve to earn weights
+TOTAL_SCORE_THRESHOLD = 0.4
 
 MAX_SCORE_DIFFERENCE = 10
 MAX_SCORE_DIFFERENCE_SOCCER = 10

--- a/vali_utils/utils.py
+++ b/vali_utils/utils.py
@@ -17,6 +17,7 @@ from storage.sqlite_validator_storage import SqliteValidatorStorage
 from common.constants import (
     IS_DEV,
     CORRECT_MATCH_WINNER_SCORE,
+    TOTAL_SCORE_THRESHOLD,
     MAX_SCORE_DIFFERENCE,
     MAX_SCORE_DIFFERENCE_SOCCER,
     MAX_SCORE_DIFFERENCE_FOOTBALL,
@@ -297,8 +298,15 @@ def find_and_score_match_predictions(batchsize: int) -> Tuple[List[float], List[
 
     # Aggregate rewards for each miner
     aggregated_rewards = defaultdict(float)
+    num_predictions_below_threshold = 0
     for uid, reward in zip(rewards_uids, rewards):
+        # Adjust the reward to 0 if it doesn't meat our threshold
+        if reward < TOTAL_SCORE_THRESHOLD:
+            num_predictions_below_threshold += 1
+            reward = 0
         aggregated_rewards[uid] += reward
+
+    bt.logging.debug(f"Total prediction scores below threshold of {TOTAL_SCORE_THRESHOLD}: {num_predictions_below_threshold} of {len(rewards)}")
 
     # Convert the aggregated rewards to a list of tuples (uid, aggregated_reward)
     aggregated_rewards_list = list(aggregated_rewards.items())


### PR DESCRIPTION
A new `TOTAL_SCORE_THRESHOLD` constant set to `0.4`.

The idea is most predictions that do not guess the correct winner will get a score of 0. There is a chance that a miner's prediction could achieve the threshold without picking the winner, but it's slim.

Anything less than that will be scored as a 0, but only for the purposes of setting weights. The actual score will still be used in a miner's overall performance posted to the API.

Overall, this should give more weight to miner's who are predicting the correct winner.

Other small updates in this PR:
1. Reducing number of miners being sent requests to 20 per run step
2. Increasing scoring cutoff days from 3 to 10. Gives more room for vali's to score predictions if they're falling behind for whatever reason